### PR TITLE
refactor: Move cosmos-specific code from metrics to cosmos pkg

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/viper"
+	"github.com/strangelove-ventures/sl-exporter/cosmos"
 	"github.com/strangelove-ventures/sl-exporter/metrics"
 )
 
@@ -17,7 +18,7 @@ type Config struct {
 		Gauges []metrics.StaticGauge
 	}
 
-	Cosmos []metrics.CosmosChain
+	Cosmos []cosmos.Chain
 }
 
 func parseConfig(cfg *Config) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,11 +73,11 @@ func Execute() {
 	}
 	// TODO(nix): Need different rest clients per chain. This hack prevents > 1 chain.
 	restClient := cosmos.NewRestClient(httpClient, *u)
-	restJobs := metrics.BuildCosmosRestJobs(cosmosMets, restClient, cfg.Cosmos)
+	restJobs := cosmos.BuildRestJobs(cosmosMets, restClient, cfg.Cosmos)
 	jobs = append(jobs, toJobs(restJobs)...)
 
 	// Initialize Cosmos validator jobs
-	valJobs := metrics.BuildCosmosValJobs(cosmosMets, restClient, cfg.Cosmos)
+	valJobs := cosmos.BuildValidatorJobs(cosmosMets, restClient, cfg.Cosmos)
 	jobs = append(jobs, toJobs(valJobs)...)
 
 	// Configure error group with signal handling.

--- a/cosmos/config.go
+++ b/cosmos/config.go
@@ -1,17 +1,17 @@
-package metrics
+package cosmos
 
 import "time"
 
-type CosmosChain struct {
+type Chain struct {
 	ChainID string
 	// Interval is how often to poll the endpoints for data.
 	Interval time.Duration
 	// Rest are the Cosmos REST (aka LCD) endpoints to poll for data.
 	Rest       []Endpoint
-	Validators []CosmosValidator
+	Validators []Validator
 }
 
-type CosmosValidator struct {
+type Validator struct {
 	// The validator's consensus address. Example prefix: cosmosvalcons...
 	ConsAddress string
 }

--- a/cosmos/rest_job_test.go
+++ b/cosmos/rest_job_test.go
@@ -1,11 +1,10 @@
-package metrics
+package cosmos
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/sl-exporter/cosmos"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,10 +19,10 @@ func (m *mockCosmosMetrics) SetNodeHeight(chain string, height float64) {
 }
 
 type mockRestClient struct {
-	StubBlock cosmos.Block
+	StubBlock Block
 }
 
-func (m *mockRestClient) LatestBlock(ctx context.Context) (cosmos.Block, error) {
+func (m *mockRestClient) LatestBlock(ctx context.Context) (Block, error) {
 	_, ok := ctx.Deadline()
 	if !ok {
 		panic("expected deadline in context")
@@ -31,34 +30,34 @@ func (m *mockRestClient) LatestBlock(ctx context.Context) (cosmos.Block, error) 
 	return m.StubBlock, nil
 }
 
-func TestCosmosRestJob_Interval(t *testing.T) {
+func TestRestJob_Interval(t *testing.T) {
 	t.Parallel()
 
-	chains := []CosmosChain{
+	chains := []Chain{
 		{Interval: time.Second},
 		{},
 	}
 
-	jobs := BuildCosmosRestJobs(nil, nil, chains)
+	jobs := BuildRestJobs(nil, nil, chains)
 
 	require.Len(t, jobs, 2)
 	require.Equal(t, time.Second, jobs[0].Interval())
 	require.Equal(t, 15*time.Second, jobs[1].Interval())
 }
 
-func TestCosmosRestJob_String(t *testing.T) {
+func TestRestJob_String(t *testing.T) {
 	t.Parallel()
 
-	chains := []CosmosChain{
+	chains := []Chain{
 		{ChainID: "cosmoshub-4"},
 	}
 
-	jobs := BuildCosmosRestJobs(nil, nil, chains)
+	jobs := BuildRestJobs(nil, nil, chains)
 
 	require.Equal(t, "Cosmos REST cosmoshub-4", jobs[0].String())
 }
 
-func TestCosmosRestJob_Run(t *testing.T) {
+func TestRestJob_Run(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -66,12 +65,12 @@ func TestCosmosRestJob_Run(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		var client mockRestClient
 
-		var blk cosmos.Block
+		var blk Block
 		blk.Block.Header.Height = "1234567890"
 		blk.Block.Header.ChainID = "cosmoshub-4"
 		client.StubBlock = blk
 
-		chains := []CosmosChain{
+		chains := []Chain{
 			{
 				ChainID: "cosmoshub-4",
 				Rest:    []Endpoint{{URL: "http://cosmos.example.com"}, {}},
@@ -83,7 +82,7 @@ func TestCosmosRestJob_Run(t *testing.T) {
 		}
 
 		var metrics mockCosmosMetrics
-		jobs := BuildCosmosRestJobs(&metrics, &client, chains)
+		jobs := BuildRestJobs(&metrics, &client, chains)
 
 		require.Len(t, jobs, 2)
 
@@ -94,10 +93,5 @@ func TestCosmosRestJob_Run(t *testing.T) {
 
 		require.Equal(t, float64(1234567890), metrics.NodeHeight)
 		require.Equal(t, "cosmoshub-4", metrics.NodeHeightChain)
-
-		job = jobs[1]
-		err = job.Run(ctx)
-		require.NoError(t, err)
-		require.Equal(t, "akash-1234", metrics.NodeHeightChain)
 	})
 }

--- a/metrics/cosmos.go
+++ b/metrics/cosmos.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/strangelove-ventures/sl-exporter/cosmos"
 )
 
 // Cosmos records metrics for Cosmos chains
@@ -36,18 +37,9 @@ func (c *Cosmos) SetNodeHeight(chain string, height float64) {
 	c.heightGauge.WithLabelValues(chain).Set(height)
 }
 
-// JailStatus is the status of a validator.
-type JailStatus int
-
-const (
-	JailStatusActive JailStatus = iota
-	JailStatusJailed
-	JailStatusTombstoned
-)
-
 // SetValJailStatus records the jailed status of a validator.
 // In this context, "active" does not mean part of the validator active set, only that the validator is not jailed.
-func (c *Cosmos) SetValJailStatus(chain, consaddress string, status JailStatus) {
+func (c *Cosmos) SetValJailStatus(chain, consaddress string, status cosmos.JailStatus) {
 	c.valJailGauge.WithLabelValues(chain, consaddress).Set(float64(status))
 }
 

--- a/metrics/cosmos_test.go
+++ b/metrics/cosmos_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/strangelove-ventures/sl-exporter/cosmos"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,10 +16,10 @@ func TestCosmos_SetNodeHeight(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		cosmos := NewCosmos()
-		reg.MustRegister(cosmos.Metrics()[0])
+		metrics := NewCosmos()
+		reg.MustRegister(metrics.Metrics()[0])
 
-		cosmos.SetNodeHeight("cosmoshub-4", 12345)
+		metrics.SetNodeHeight("cosmoshub-4", 12345)
 
 		h := metricsHandler(reg)
 		r := httptest.NewRecorder()
@@ -33,10 +34,10 @@ sl_exporter_cosmos_latest_block_height{chain_id="cosmoshub-4"} 12345
 
 	t.Run("url with path", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		cosmos := NewCosmos()
-		reg.MustRegister(cosmos.Metrics()...)
+		metrics := NewCosmos()
+		reg.MustRegister(metrics.Metrics()...)
 
-		cosmos.SetNodeHeight("cosmoshub-4", 12345)
+		metrics.SetNodeHeight("cosmoshub-4", 12345)
 
 		h := metricsHandler(reg)
 		r := httptest.NewRecorder()
@@ -50,20 +51,20 @@ sl_exporter_cosmos_latest_block_height{chain_id="cosmoshub-4"} 12345
 func TestCosmos_SetValJailStatus(t *testing.T) {
 	t.Parallel()
 
-	cosmos := NewCosmos()
+	metrics := NewCosmos()
 	reg := prometheus.NewRegistry()
-	reg.MustRegister(cosmos.Metrics()[1])
+	reg.MustRegister(metrics.Metrics()[1])
 	h := metricsHandler(reg)
 
 	for _, tt := range []struct {
-		Status    JailStatus
+		Status    cosmos.JailStatus
 		WantValue int
 	}{
-		{Status: JailStatusActive, WantValue: 0},
-		{Status: JailStatusJailed, WantValue: 1},
-		{Status: JailStatusTombstoned, WantValue: 2},
+		{Status: cosmos.JailStatusActive, WantValue: 0},
+		{Status: cosmos.JailStatusJailed, WantValue: 1},
+		{Status: cosmos.JailStatusTombstoned, WantValue: 2},
 	} {
-		cosmos.SetValJailStatus("cosmoshub-4", "cosmosvalcons123", tt.Status)
+		metrics.SetValJailStatus("cosmoshub-4", "cosmosvalcons123", tt.Status)
 		r := httptest.NewRecorder()
 		h.ServeHTTP(r, stubRequest)
 


### PR DESCRIPTION
I feel this is better organization. 

This does NOT change functionality. Only renames and moves. 

Given how we want to extend this exporter, you can imagine these future packages:
```
ethereum - For Eth functionality
exchange - For gathering token prices from a source like Coingecko
```

I almost moved `static` to its own package, but it's so simple I kept it in `metrics`. 