### PR TITLE
refactor: Remove latest from validator metrics

### DIFF
--- a/metrics/cosmos.go
+++ b/metrics/cosmos.go
@@ -26,7 +26,7 @@ func NewCosmos() *Cosmos {
 		),
 		valJailGauge: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: prometheus.BuildFQName(namespace, cosmosValSubsystem, "latest_jailed_status"),
+				Name: prometheus.BuildFQName(namespace, cosmosValSubsystem, "jailed_status"),
 				Help: "0 if the cosmos validator is not jailed. 1 if the validator is jailed. 2 if the validator is tombstoned.",
 			},
 			[]string{"chain_id", "address"},
@@ -40,14 +40,14 @@ func NewCosmos() *Cosmos {
 		),
 		valSignedBlock: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: prometheus.BuildFQName(namespace, cosmosValSubsystem, "latest_signed_block_height"),
+				Name: prometheus.BuildFQName(namespace, cosmosValSubsystem, "signed_block_height"),
 				Help: "The latest observed block signed by a cosmos validator.",
 			},
 			[]string{"chain_id", "address"},
 		),
 		valMissedBlocks: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: prometheus.BuildFQName(namespace, cosmosValSubsystem, "latest_missed_blocks"),
+				Name: prometheus.BuildFQName(namespace, cosmosValSubsystem, "missed_blocks"),
 				Help: "The number of missed blocks within the slashing window by a cosmos validator.",
 			},
 			[]string{"chain_id", "address"},

--- a/metrics/cosmos_test.go
+++ b/metrics/cosmos_test.go
@@ -48,7 +48,7 @@ func TestCosmos_SetValJailStatus(t *testing.T) {
 		h.ServeHTTP(r, stubRequest)
 
 		want := fmt.Sprintf(`
-sl_exporter_cosmos_val_latest_jailed_status{address="cosmosvalcons123",chain_id="cosmoshub-4"} %d`,
+sl_exporter_cosmos_val_jailed_status{address="cosmosvalcons123",chain_id="cosmoshub-4"} %d`,
 			tt.WantValue)
 
 		require.Contains(t, r.Body.String(), want, tt)
@@ -87,7 +87,7 @@ func TestCosmos_SetValSignedBlock(t *testing.T) {
 	r := httptest.NewRecorder()
 	h.ServeHTTP(r, stubRequest)
 
-	const want = `sl_exporter_cosmos_val_latest_signed_block_height{address="cosmosvalcons123",chain_id="cosmoshub-4"} 12345`
+	const want = `sl_exporter_cosmos_val_signed_block_height{address="cosmosvalcons123",chain_id="cosmoshub-4"} 12345`
 	require.Contains(t, r.Body.String(), want)
 }
 
@@ -104,7 +104,7 @@ func TestCosmos_SetValMissedBlocks(t *testing.T) {
 	r := httptest.NewRecorder()
 	h.ServeHTTP(r, stubRequest)
 
-	const want = `sl_exporter_cosmos_val_latest_missed_blocks{address="cosmosvalcons123",chain_id="cosmoshub-4"} 9`
+	const want = `sl_exporter_cosmos_val_missed_blocks{address="cosmosvalcons123",chain_id="cosmoshub-4"} 9`
 	require.Contains(t, r.Body.String(), want)
 }
 


### PR DESCRIPTION
Per a good suggestion from Nour. 

Repeating the word `latest` in the metrics does not add much value. 

I kept the existing block height metric (non-validator) as `...latest_block_height` because I feel there is value there. 